### PR TITLE
ui(mosaic): Modify grid layout to show preview

### DIFF
--- a/web/src/components/simulation_editor.rs
+++ b/web/src/components/simulation_editor.rs
@@ -73,7 +73,6 @@ impl Component for SimulationEditor {
             "grid-cols-1",
             "lg:grid-cols-2",
             "gap-2",
-            "lg:grid-rows-2",
             props.class.clone()
         );
 
@@ -92,7 +91,12 @@ impl Component for SimulationEditor {
                     </div>
                 </div>
 
-                <div class="flex flex-col h-full lg:row-start-2 space-y-2">
+                <div class="flex flex-col">
+                    <label for="source">{"Module"}</label>
+                    <textarea name="source" ref={self.source_ref.clone()} />
+                </div>
+
+                <div class="flex flex-col h-full space-y-2">
                     <p>{"Initial state"}</p>
                     <div class="space-x-4">
                         <label for="seed">{"Seed"}</label>
@@ -103,11 +107,6 @@ impl Component for SimulationEditor {
                             <Grid prev={Blocks::default()} next={self.preview} class="h-full w-full" />
                         </div>
                     </div>
-                </div>
-
-                <div class="flex flex-col lg:row-start-1 lg:col-start-2 lg:row-span-2">
-                    <label for="source">{"Module"}</label>
-                    <textarea name="source" ref={self.source_ref.clone()} />
                 </div>
             </form>
         }


### PR DESCRIPTION
The preview of the state was being pushed down because it was starting on row 2. Try and let the browser handle more of the packing and move the editor as the second div so it's rendered first. This seems to lead to a layout like

[ docs ]   [ editor]

[ state ]

When viewed at smaller screen resolution, then everything is rendered in a single column.

Example on desktop
<img width="1434" alt="image" src="https://github.com/jdkaplan/EmptyBlock.dev/assets/1429850/f197173a-b419-4ee9-9e3c-b1fddc3a88c4">

Example on "mobile"
![Screenshot_20240626-151553](https://github.com/jdkaplan/EmptyBlock.dev/assets/1429850/fd4ba19c-fd72-4ff5-be40-ad25ae8d01f3)

fix #45 