### PR TITLE
infra: Keep at least one machine running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,4 +10,4 @@ internal_port = 8080
 force_https = true
 auto_stop_machines = true
 auto_start_machines = true
-min_machines_running = 0
+min_machines_running = 1


### PR DESCRIPTION
To run cron jobs, there needs to be at least one machine running to run the job. The easiest way to make sure that happens is to permanently keep at least one app machine up.

Closes #34
